### PR TITLE
test on linux and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 sudo: required
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.8
   - 1.9

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Travis-ci doesn't support docker..
+# https://docs.travis-ci.com/user/docker/
+if [ "$TRAVIS_OS_NAME" == "osx" ];
+then
+    echo "TravisCI currently does not support docker on osx, skipping tests"
+    exit 0
+fi
+
 # Run each build's tests
 platforms=(alpine-36 debian-8 debian-9 ubuntu-1604 ubuntu-1704)
 for plat in "${platforms[@]}"

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Run each build's tests
 platforms=(alpine-36 debian-8 debian-9 ubuntu-1604 ubuntu-1704)
@@ -7,4 +6,9 @@ for plat in "${platforms[@]}"
 do
     echo "CI: $plat"
     ./build/"$plat"/test.sh
+    if [ ! $? -eq 0 ];
+    then
+        cat ./build/"$plat"/test.log
+        exit 1
+    fi
 done

--- a/store/darwin_test.go
+++ b/store/darwin_test.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/adamdecaf/cert-manage/tools/file"
 )
 
 func TestStoreDarwin__Backup(t *testing.T) {
@@ -70,17 +68,21 @@ func TestStoreDarwin__locations(t *testing.T) {
 	userDirs, _ := getUserDirs()
 	paths = append(paths, userDirs...)
 
+	count := 0
+
 	for _, p := range paths {
 		certs, err := readInstalledCerts(p)
 		if err != nil {
 			t.Errorf("%s - err=%v", p, err)
 		}
-		if len(certs) == 0 && file.Exists(p) {
-			t.Error("didn't find any certs")
+		count += len(certs)
+
+		if !debug {
+			continue
 		}
-		if debug {
-			fmt.Printf("%d certs from %s\n", len(certs), p)
-		}
+
+		// Debug info
+		fmt.Printf("%d certs from %s\n", len(certs), p)
 		out := make([]string, 0)
 		for i := range certs {
 			if certs[i].Subject.CommonName != "" {
@@ -92,10 +94,12 @@ func TestStoreDarwin__locations(t *testing.T) {
 				continue
 			}
 		}
-		if debug {
-			sort.Strings(out)
-			fmt.Printf("%s\n", strings.Join(out, "\n"))
-		}
+		sort.Strings(out)
+		fmt.Printf("%s\n", strings.Join(out, "\n"))
+	}
+
+	if count == 0 {
+		t.Errorf("Didn't find any certs from all %d paths", len(paths))
 	}
 }
 

--- a/store/darwin_test.go
+++ b/store/darwin_test.go
@@ -20,7 +20,7 @@ func TestStoreDarwin__Backup(t *testing.T) {
 		t.Error(err)
 	}
 	namesBefore, err := ioutil.ReadDir(dir)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
Travis-CI doesn't yet support windows and osx doesn't support docker.. Thankfully we're still getting coverage by running all go tests and `make ci` on linux (and my dev machine). 

Docs: https://docs.travis-ci.com/user/multi-os/

See: https://github.com/travis-ci/travis-ci/issues/2104