### PR TITLE
build: test against 1.x bugfix releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os:
   - osx
 
 go:
-  - 1.8
-  - 1.9
+  - 1.8.x
+  - 1.9.x
   - master
 
 jdk:


### PR DESCRIPTION
`gimme` by default uses 1.x exactly, not the latest bugfix

https://groups.google.com/d/msg/golang-dev/ONpj39nviNg/6gTtcs3HAQAJ