### PR TITLE
cmd: Pass around a Config object

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,10 @@
+package cmd
+
+type Config struct {
+	// If we should only show the certificate count, rather than each one
+	Count bool
+
+	// What format to print certificates in, formats are defined in ../main.go and
+	// checked in print.go
+	Format string
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,16 +10,16 @@ import (
 // ListCertsForPlatform finds certs for the given platform.
 // The supported platforms can be found in the readme. They're compiled in
 // with build flags in the `certs/find_*.go` files.
-func ListCertsForPlatform(count bool, format string) error {
+func ListCertsForPlatform(cfg *Config) error {
 	certificates, err := store.Platform().List()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if count {
+	if cfg.Count {
 		fmt.Println(len(certificates))
 	} else {
-		printCerts(certificates, format)
+		printCerts(certificates, cfg.Format)
 	}
 	return nil
 }
@@ -27,7 +27,7 @@ func ListCertsForPlatform(count bool, format string) error {
 // ListCertsForApp finds certs for the given app.
 // The supported applications are listed in the readme. This includes
 // non-traditional applications like NSS.
-func ListCertsForApp(app string, count bool, format string) error {
+func ListCertsForApp(app string, cfg *Config) error {
 	st, err := store.ForApp(app)
 	if err != nil {
 		fmt.Println(err)
@@ -47,10 +47,10 @@ func ListCertsForApp(app string, count bool, format string) error {
 	}
 
 	// Output the certificates
-	if count {
+	if cfg.Count {
 		fmt.Println(len(certificates))
 	} else {
-		printCerts(certificates, format)
+		printCerts(certificates, cfg.Format)
 	}
 	return nil
 }

--- a/cmd/whitelist.go
+++ b/cmd/whitelist.go
@@ -5,7 +5,7 @@ import (
 	"github.com/adamdecaf/cert-manage/whitelist"
 )
 
-func WhitelistForApp(app, whpath, format string) error {
+func WhitelistForApp(app, whpath string) error {
 	// load whitelist
 	wh, err := whitelist.FromFile(whpath)
 	if err != nil {
@@ -25,7 +25,7 @@ func WhitelistForApp(app, whpath, format string) error {
 	return nil
 }
 
-func WhitelistForPlatform(whpath, format string) error {
+func WhitelistForPlatform(whpath string) error {
 	// load whitelist
 	wh, err := whitelist.FromFile(whpath)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -64,6 +64,12 @@ func main() {
 		return
 	}
 
+	// Lift config options into a higher-level
+	cfg := &cmd.Config{
+		Count:  *count,
+		Format: *format,
+	}
+
 	// Perform a restore
 	// Note: This always needs to happen before -whitelist and before -backup
 	if restore != nil && *restore {
@@ -101,10 +107,10 @@ func main() {
 		}
 		err := appChoice(app,
 			func(a string) error {
-				return cmd.WhitelistForApp(a, *file, *format)
+				return cmd.WhitelistForApp(a, *file)
 			},
 			func() error {
-				return cmd.WhitelistForPlatform(*file, *format)
+				return cmd.WhitelistForPlatform(*file)
 			})
 		exit("Whitelist completed successfully", err)
 		return
@@ -114,10 +120,10 @@ func main() {
 	if list != nil && *list {
 		err := appChoice(app,
 			func(a string) error {
-				return cmd.ListCertsForApp(*app, *count, *format)
+				return cmd.ListCertsForApp(*app, cfg)
 			},
 			func() error {
-				return cmd.ListCertsForPlatform(*count, *format)
+				return cmd.ListCertsForPlatform(cfg)
 			})
 		exit("", err)
 		return


### PR DESCRIPTION
A refactor for https://github.com/adamdecaf/cert-manage/issues/14 will take some more work, but I didn't want to leave the `cmd.Config` hanging and run into conflicts before the rest is done. 