### PR TITLE
store/darwin: mock out darwin by default, allow DEUBG override

### DIFF
--- a/store/darwin.go
+++ b/store/darwin.go
@@ -53,7 +53,10 @@ const (
 type darwinStore struct{}
 
 func platform() Store {
-	return darwinStore{}
+	if debug {
+		return darwinStore{}
+	}
+	return emptyStore{}
 }
 
 func (s darwinStore) Backup() error {

--- a/store/empty.go
+++ b/store/empty.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/adamdecaf/cert-manage/whitelist"
+)
+
+// emptyStore represents a Store which has no implementation
+// This is useful for stubs
+type emptyStore struct{}
+
+func (s emptyStore) printNotce() {
+	fmt.Fprintln(os.Stderr, "NOTICE: This implementation is currently stubbed, nothing is happening.")
+}
+
+func (s emptyStore) Backup() error {
+	s.printNotce()
+	return nil
+}
+func (s emptyStore) List() ([]*x509.Certificate, error) {
+	s.printNotce()
+	return nil, nil
+}
+func (s emptyStore) Remove(whitelist.Whitelist) error {
+	s.printNotce()
+	return nil
+}
+func (s emptyStore) Restore(where string) error {
+	s.printNotce()
+	return nil
+}

--- a/test/integration.go
+++ b/test/integration.go
@@ -61,8 +61,20 @@ func CertManage(args ...string) *Cmd {
 
 func (c *Cmd) exec() {
 	c.Do(func() {
-		out, err := exec.Command(c.command, c.args...).CombinedOutput()
-		c.output = string(out)
+		cmd := exec.Command(c.command, c.args...)
+
+		// Set output collectors
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		if err == nil {
+			c.output = stdout.String()
+		} else {
+			c.output = stderr.String()
+		}
 		c.err = err
 	})
 	return

--- a/test/integration_darwin_test.go
+++ b/test/integration_darwin_test.go
@@ -26,6 +26,8 @@ func TestIntegration__unknown(t *testing.T) {
 }
 
 func TestIntegration__list(t *testing.T) {
+	t.Skip("darwin support is wip")
+
 	cmd := CertManage("list", "-count").Trim()
 	cmd.CmpIntF(t, func(i int) bool { return i > 1 })
 }


### PR DESCRIPTION
```
$ ./cert-manage list -count
NOTICE: This implementation is currently stubbed, nothing is happening.
0
```

VS

```
$ DEBUG=1 ./cert-manage list -count
...
188
```

Issue: https://github.com/adamdecaf/cert-manage/issues/9