### PR TITLE
cmd/gen: build whitelist from platform/app roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build/*/*.class
 
 *.yaml
 !testdata/*.yaml
+*.json
+!testdata/*.json

--- a/pkg/cmd/gen_whitelist.go
+++ b/pkg/cmd/gen_whitelist.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/adamdecaf/cert-manage/pkg/certutil"
+	"github.com/adamdecaf/cert-manage/pkg/store"
 	"github.com/adamdecaf/cert-manage/pkg/whitelist"
 	"github.com/adamdecaf/cert-manage/pkg/whitelist/gen"
 )
@@ -37,6 +38,8 @@ func GenerateWhitelist(output string, from, file string) error {
 	uacc := make(chan []*url.URL)
 	eacc := make(chan error)
 
+	pool := x509.NewCertPool()
+
 	choices := getChoices(from, file)
 	debugLog("running %d choices\n", len(choices))
 	for i := range choices {
@@ -45,18 +48,21 @@ func GenerateWhitelist(output string, from, file string) error {
 		case "browser", "browsers":
 			debugLog("starting browser url retrieval")
 			go accumulateUrls(gen.FromAllBrowsers, uacc, eacc)
+			addCertsToPool(pool, gen.BrowserCAs)
 
 		case "file":
 			debugLog("grabbing urls from %s", file)
 			go accumulateUrls(func() ([]*url.URL, error) {
 				return gen.FromFile(file)
 			}, uacc, eacc)
+			addCertsToPool(pool, store.Platform().List)
 
 		default:
 			debugLog("starting %s url retrieval", opt)
 			go accumulateUrls(func() ([]*url.URL, error) {
 				return gen.FromBrowser(opt)
 			}, uacc, eacc)
+			addCertsToPoolForApp(pool, opt)
 		}
 	}
 
@@ -80,7 +86,7 @@ func GenerateWhitelist(output string, from, file string) error {
 	}
 
 	// Generate whitelist and write to file
-	authorities, err := gen.FindCAs(accum)
+	authorities, err := gen.FindCAs(accum, pool)
 	if err != nil {
 		return err
 	}
@@ -132,6 +138,23 @@ func accumulateUrls(f func() ([]*url.URL, error), u chan []*url.URL, e chan erro
 		debugLog("adding %d urls", len(urls))
 		u <- urls
 	}
+}
+
+func addCertsToPool(pool *x509.CertPool, f func() ([]*x509.Certificate, error)) {
+	certs, err := f()
+	if err == nil {
+		for i := range certs {
+			pool.AddCert(certs[i])
+		}
+	}
+}
+
+func addCertsToPoolForApp(pool *x509.CertPool, appName string) {
+	st, err := store.ForApp(appName)
+	if err != nil {
+		st = store.Platform() // try and give something as a root store
+	}
+	addCertsToPool(pool, st.List)
 }
 
 func debugLog(msg string, args ...interface{}) {

--- a/pkg/cmd/gen_whitelist.go
+++ b/pkg/cmd/gen_whitelist.go
@@ -21,7 +21,7 @@ import (
 var (
 	debug = os.Getenv("DEBUG") != ""
 
-	exampleDNSNamesLength = 5
+	exampleDNSNamesLength = 3
 )
 
 func GenerateWhitelist(output string, from, file string) error {
@@ -94,7 +94,7 @@ func GenerateWhitelist(output string, from, file string) error {
 	// prep summary
 	sortCAs(authorities)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "CA\tDNSName Count\tExample DNSNames")
+	fmt.Fprintln(w, "CA\tFingerprint\tCount\tExample DNSNames")
 
 	var acc []*x509.Certificate
 	for i := range authorities {

--- a/pkg/whitelist/gen/browser.go
+++ b/pkg/whitelist/gen/browser.go
@@ -1,28 +1,38 @@
 package gen
 
 import (
+	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/adamdecaf/cert-manage/pkg/store"
 )
 
 type getter func() ([]*url.URL, error)
 
-func FromAllBrowsers() ([]*url.URL, error) {
-	gets := []getter{
+var (
+	browserGetters = []getter{
 		chrome,
 		firefox,
 	}
 
+	// requires updating with store/store.go, but so does the
+	// rest of this file
+	browserNames = []string{"chrome", "firefox"}
+)
+
+func FromAllBrowsers() ([]*url.URL, error) {
 	var acc []*url.URL
 	mu := sync.Mutex{}
 	wg := sync.WaitGroup{}
-	wg.Add(len(gets))
+	wg.Add(len(browserGetters))
 
-	for i := range gets {
+	for i := range browserGetters {
 		go func(i int) {
-			urls, _ := gets[i]()
+			urls, _ := browserGetters[i]()
 			mu.Lock()
 			acc = append(acc, urls...)
 			mu.Unlock()
@@ -36,6 +46,21 @@ func FromAllBrowsers() ([]*url.URL, error) {
 		return acc, errors.New("no browser history found")
 	}
 	return acc, nil
+}
+
+func BrowserCAs() ([]*x509.Certificate, error) {
+	var out []*x509.Certificate
+	for i := range browserNames {
+		st, err := store.ForApp(browserNames[i])
+		if err != nil {
+			fmt.Printf("WARNING: error getting hard-coded browser %s, err=%v\n", browserNames[i], err)
+		}
+		certs, err := st.List()
+		if err == nil {
+			out = append(out, certs...)
+		}
+	}
+	return out, nil
 }
 
 func FromBrowser(name string) ([]*url.URL, error) {

--- a/pkg/whitelist/gen/gen.go
+++ b/pkg/whitelist/gen/gen.go
@@ -217,7 +217,7 @@ func FindCAs(urls []*url.URL, sysRoots *x509.CertPool) ([]*CA, error) {
 			}
 
 			// remind people we're still here
-			if i > 0 && ((i < 1000 && i%100 == 0) || i%1000 == 0) {
+			if i >= 1000 && i%1000 == 0 {
 				fmt.Printf("Processed %d/%d urls\n", i, len(urls))
 			}
 		}(workers, urls[i], i)

--- a/pkg/whitelist/gen/gen_test.go
+++ b/pkg/whitelist/gen/gen_test.go
@@ -25,10 +25,11 @@ func TestGen__caSigns(t *testing.T) {
 	}
 
 	// add signers
-	ca.addDNSNames([]string{
-		"google.com", "*.gmail.com",
-		"google.com", "*.gmail.com",
-	})
+	ca.addDNSName("google.com")
+	ca.addDNSName("*.gmail.com")
+	ca.addDNSName("google.com")
+	ca.addDNSName("*.gmail.com")
+
 	// check we didn't add duplicates
 	if len(ca.DNSNames) != 2 {
 		t.Errorf("got %d", len(ca.DNSNames))
@@ -67,9 +68,14 @@ func TestGen__caFind(t *testing.T) {
 		t.Errorf("bad fingerprint, got %q", ca.Fingerprint)
 	}
 
-	if len(ca.DNSNames) != 2 {
-		t.Errorf("got %d", len(ca.DNSNames))
+	if len(ca.DNSNames) != 0 {
+		t.Errorf("somehow DNSNames were added..")
 	}
+
+	// manually call .addDNSName() and check
+	ca.addDNSName("*.banno.com")
+	ca.addDNSName("banno.com")
+
 	ans := []string{"*.banno.com", "banno.com"}
 	if !reflect.DeepEqual(ca.DNSNames, ans) {
 		t.Errorf("got %q", ca.DNSNames)


### PR DESCRIPTION
Before we would only rely on the root cert presented in the bundle
from whatever remote server. This doesn't work that well as the cert
we care about lives in the platform/app store.

Fixes: https://github.com/adamdecaf/cert-manage/issues/124