### PR TITLE
store/linux: drop sudo if we're root

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,5 @@
 ## cert-manage Roadmap
 
-### 0.1.0
-
-#### Get linux support 100%
-
-- `escalate via sudo/su if needed and able`: https://github.com/adamdecaf/cert-manage/issues/134
-
 ### 0.2.0
 
 store/java: accept -file


### PR DESCRIPTION
I think the advice for now (on systems without sudo) would be to run
this as root. You'd probably need that to refresh certs or mv/cp them
around anyway.

Issue: https://github.com/adamdecaf/cert-manage/issues/134